### PR TITLE
Fixes for injecting FXMLLoader in Dagger sample

### DIFF
--- a/dagger/src/main/java/com/gluonhq/hello/HelloGluon.java
+++ b/dagger/src/main/java/com/gluonhq/hello/HelloGluon.java
@@ -37,6 +37,7 @@ import com.gluonhq.hello.views.SecondPresenter;
 import com.gluonhq.ignite.dagger.DaggerContext;
 import dagger.Module;
 import dagger.Provides;
+import dagger.internal.Loader;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Dimension2D;
 import javafx.scene.Parent;
@@ -49,19 +50,22 @@ import java.util.ResourceBundle;
 
 public class HelloGluon extends MobileApplication {
 
-    private final DaggerContext context = new DaggerContext(this, () -> Collections.singletonList(new DaggerModule()));
-
     public static final String PRIMARY_VIEW = HOME_VIEW;
     public static final String SECONDARY_VIEW = "Secondary View";
 
-    @Inject
-    FXMLLoader fxmlLoader;
+    private static final String VIEW_LOCATION = "com/gluonhq/hello/views/";
+
+
+    private final DaggerContext context = new DaggerContext(this, () -> Collections.singletonList(new DaggerModule()));
 
     @Override
     public void init() throws IOException {
+
+
         context.init();
 
-        addViewFactory(PRIMARY_VIEW, () -> (View) loadFXML(fxmlLoader, "first"));
+        addViewFactory(PRIMARY_VIEW,   () -> loadFXML("first"));
+        addViewFactory(SECONDARY_VIEW, () -> loadFXML("second"));
 
         DrawerManager.buildDrawer(this);
     }
@@ -84,9 +88,12 @@ public class HelloGluon extends MobileApplication {
         launch();
     }
 
-    public Parent loadFXML(FXMLLoader fxmlLoader, String name) {
-        fxmlLoader.setLocation(getClass().getResource("/com/gluonhq/hello/views/" + name + ".fxml"));
-        fxmlLoader.setResources( ResourceBundle.getBundle("com.gluonhq.hello.views." + name));
+    public View loadFXML(String name) {
+
+        FXMLLoader fxmlLoader = context.getInstance(FXMLLoader.class);
+
+        fxmlLoader.setLocation(getClass().getResource('/' + VIEW_LOCATION + name + ".fxml"));
+        fxmlLoader.setResources( ResourceBundle.getBundle(  VIEW_LOCATION.replace('/', '.') + name));
         try {
             return fxmlLoader.load();
         } catch (IOException e) {
@@ -96,7 +103,7 @@ public class HelloGluon extends MobileApplication {
     }
 }
 
-@Module( library = true, injects = {HelloGluon.class, FirstPresenter.class, SecondPresenter.class}, complete = false)
+@Module( library = true, injects = {FXMLLoader.class, HelloGluon.class, FirstPresenter.class, SecondPresenter.class }, complete = false)
 class DaggerModule  {
 
     @Provides
@@ -105,5 +112,6 @@ class DaggerModule  {
     }
 
 }
+
 
 

--- a/dagger/src/main/java/com/gluonhq/hello/views/FirstPresenter.java
+++ b/dagger/src/main/java/com/gluonhq/hello/views/FirstPresenter.java
@@ -17,6 +17,8 @@ import static com.gluonhq.hello.HelloGluon.SECONDARY_VIEW;
 
 public class FirstPresenter {
 
+    private static MobileApplication appManager = MobileApplication.getInstance();
+
     @FXML
     private View first;
 
@@ -35,7 +37,6 @@ public class FirstPresenter {
     public void initialize() {
         first.showingProperty().addListener((obs, oldValue, newValue) -> {
             if (newValue) {
-                MobileApplication appManager = MobileApplication.getInstance();
                 AppBar appBar = appManager.getAppBar();
                 appBar.setNavIcon(MaterialDesignIcon.MENU.button(e -> appManager.getDrawer().open()));
                 appBar.setTitleText("First");
@@ -50,8 +51,6 @@ public class FirstPresenter {
     void buttonClick() {
         // label.setText(resources.getString("label.text.2"));
         System.out.println(service.getText());
-        final HelloGluon helloGluon = (HelloGluon) HelloGluon.getInstance();
-        helloGluon.addViewFactory(SECONDARY_VIEW, () -> (View) helloGluon.loadFXML(fxmlLoader, "second"));
-        helloGluon.switchView(SECONDARY_VIEW);
+        appManager.switchView(HelloGluon.SECONDARY_VIEW);
     }
 }

--- a/dagger/src/main/java/com/gluonhq/hello/views/SecondPresenter.java
+++ b/dagger/src/main/java/com/gluonhq/hello/views/SecondPresenter.java
@@ -14,6 +14,8 @@ import javax.inject.Inject;
 
 public class SecondPresenter  {
 
+    private static MobileApplication appManager = MobileApplication.getInstance();
+
     @FXML
     private View second;
 
@@ -22,17 +24,17 @@ public class SecondPresenter  {
     @Inject
     Service service;
 
+
+
     public void initialize() {
         second.setShowTransitionFactory(BounceInRightTransition::new);
 
-        FloatingActionButton fab = new FloatingActionButton(MaterialDesignIcon.INFO.text,
-                e -> MobileApplication.getInstance().goHome());
+        FloatingActionButton fab = new FloatingActionButton(MaterialDesignIcon.INFO.text, e -> appManager.goHome());
 
         fab.showOn(second);
 
         second.showingProperty().addListener((obs, oldValue, newValue) -> {
             if (newValue) {
-                MobileApplication appManager = MobileApplication.getInstance();
                 AppBar appBar = appManager.getAppBar();
                 appBar.setNavIcon(MaterialDesignIcon.MENU.button(e -> appManager.getDrawer().open()));
                 appBar.setTitleText("Second");


### PR DESCRIPTION
Fixed few things around Dagger sample. 
Main issue is that `FXMLLoader.class` should be part of module definition, which is not good, since we don't want developers to remember that. This has to be a part of default module definition in `Ignite`